### PR TITLE
Add test action for ramses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,85 @@
+name: Test
+
+# This is derived from the standard CMake template for github actions.
+# For more details on the settings used, have a look at the template in the marketplace
+
+# Only pushes and PRs against the master branch are built
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    # Strategy: builds on oldest and newest Ubuntu and on Windows
+    # Oldest -> because that's what is used to build backwards compatible packages (see release.yaml)
+    # Newest -> so that we can test with latest tools (clang-tidy) and use recent drivers/packages
+    strategy:
+      matrix:
+        os: [ubuntu-20.04,  windows-2022]
+        type: [Debug, Release]
+        # on Windows we skip Debug because otherwise the hosted runner runs out of space
+        exclude:
+          - os: windows-2022
+            type: Debug
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+
+    - name: Install GL/X11 packages for rendering (Linux only)
+      run: |
+        sudo apt-get install libgles2-mesa-dev libx11-dev
+      if: ${{ contains(matrix.os, 'ubuntu') }}
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake (Windows)
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: |
+        # This is needed because on the Windows Server 2019 build nodes of Github, the Perl installation
+        # exposes its libraries on the path and messes up CMake builds
+        restore_path=$PATH
+        echo "Path before: $PATH"
+        export PATH=$(echo "$PATH" | sed -e 's/:\/c\/Strawberry\/c\/bin//')
+        export PATH=$(echo "$PATH" | sed -e 's/:\/c\/Strawberry\/perl\/site\/bin//')
+        export PATH=$(echo "$PATH" | sed -e 's/:\/c\/Strawberry\/perl\/bin//')
+        echo "Path after: $PATH"
+
+        # Limiting CMAKE_CONFIGURATION_TYPES for MSVC improves build time and reduces diskspace usage
+        cmake $GITHUB_WORKSPACE \
+            -DCMAKE_BUILD_TYPE=${{ matrix.type }} \
+            -DCMAKE_CONFIGURATION_TYPES=${{ matrix.type }}
+      if: ${{ contains(matrix.os, 'windows') }}
+
+    - name: Configure CMake (Latest Ubuntu + Clang)
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: |
+        cmake $GITHUB_WORKSPACE \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
+            -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/cmake/toolchain/Linux_X86_64_llvm.toolchain \
+            -DCMAKE_BUILD_TYPE=${{ matrix.type }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+
+    - name: Configure CMake (Oldest Ubuntu + GCC)
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: |
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.type }}
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config ${{ matrix.type }}
+
+    - name: Run unit tests (exclude rendering tests)
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: ctest -C ${{ matrix.type }} --exclude-regex '.*RNDSANDWICHTEST'


### PR DESCRIPTION
Uses pinned runners for stability.
Based on learnings from ramses logic.
Builds matrix of windows/linux in release and
debug. Excludes the debug build for windows because it hits the 16GB diskspace limit on Github actions nodes.