### PR TITLE
Handle warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ project(ramses-sdk
 )
 
 # build options
-option(ramses-sdk_WARNINGS_AS_ERRORS "If on, warnings are treated as errors during build." OFF)
+option(ramses-sdk_WARNINGS_AS_ERRORS "If on, warnings are treated as errors during build." ON)
 # TODO Building tests should be off when building ramses externally
 option(ramses-sdk_BUILD_TESTS "Build ramses tests." ON)
 option(ramses-sdk_BUILD_SMOKE_TESTS "Build smoke tests." ON) # TODO document how this interacts with the above option

--- a/framework/Communication/TransportTCP/include/TransportTCP/AsioWrapper.h
+++ b/framework/Communication/TransportTCP/include/TransportTCP/AsioWrapper.h
@@ -15,6 +15,7 @@
 WARNINGS_PUSH
 WARNING_DISABLE_LINUX(-Wold-style-cast)
 WARNING_DISABLE_GCC(-Wsuggest-override)
+WARNING_DISABLE_GCC(-Wmaybe-uninitialized)
 WARNING_DISABLE_CLANG(-Wunused-private-field)
 WARNING_DISABLE_CLANG(-Wshadow)
 WARNING_DISABLE_CLANG(-Wimplicit-fallthrough)

--- a/framework/SceneGraph/Scene/include/Scene/SceneActionCollection.h
+++ b/framework/SceneGraph/Scene/include/Scene/SceneActionCollection.h
@@ -157,9 +157,15 @@ namespace ramses_internal
             UInt m_readPosition;
         };
 
-        class Iterator : public std::iterator<std::forward_iterator_tag, SceneActionReader, UInt, SceneActionReader*, SceneActionReader&>
+        class Iterator
         {
         public:
+            using iterator_category = std::forward_iterator_tag;
+            using value_type = SceneActionReader;
+            using difference_type = std::ptrdiff_t;
+            using pointer = SceneActionReader*;
+            using reference = SceneActionReader&;
+
             Iterator();
 
             bool operator!=(const Iterator& other) const;

--- a/utils/ramses-imgui/include/ImguiWidgets.h
+++ b/utils/ramses-imgui/include/ImguiWidgets.h
@@ -8,17 +8,15 @@
 
 #pragma once
 
-#ifndef _MSC_VER
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif
+#include "Utils/Warnings.h"
+
+WARNINGS_PUSH
+WARNING_DISABLE_LINUX(-Wold-style-cast)
 
 #include "imgui.h"
 #include "misc/cpp/imgui_stdlib.h"
 
-#ifndef _MSC_VER
-#pragma GCC diagnostic pop
-#endif
+WARNINGS_POP
 
 #include "absl/types/span.h"
 #include "SceneAPI/TextureEnums.h"

--- a/utils/ramses-imgui/src/ImguiWidgets.cpp
+++ b/utils/ramses-imgui/src/ImguiWidgets.cpp
@@ -15,9 +15,16 @@
 
 #include "fmt/format.h"
 
-
 namespace ramses_internal
 {
+    // TODO Find a better solution to this. For now, needed to suppress cast warnings
+    WARNINGS_PUSH
+    WARNING_DISABLE_LINUX(-Wold-style-cast)
+    constexpr auto white{IM_COL32(255, 255, 255, 255)};
+    constexpr auto grey{IM_COL32(200, 200, 200, 255)};
+    constexpr auto green{IM_COL32(15, 200, 19, 255)};
+    WARNINGS_POP
+
     namespace imgui
     {
         namespace
@@ -165,9 +172,6 @@ namespace ramses_internal
                 valueHasChanged = true;
             }
 
-            constexpr auto white{IM_COL32(255, 255, 255, 255)};
-            constexpr auto grey{IM_COL32(200, 200, 200, 255)};
-            constexpr auto green{IM_COL32(15, 200, 19, 255)};
             ImU32          backgroundColor;
             float          offsetOnPosition = 0;
             if (value)


### PR DESCRIPTION
Handle warnings as errors.
Suppresses warnings in dependencies by disabling them in the
header wrappers or using alternative code which doesn't produce a warning.