### PR TITLE
Catch extra warning

### DIFF
--- a/cmake/ramses/platformConfig.cmake
+++ b/cmake/ramses/platformConfig.cmake
@@ -112,7 +112,7 @@ endif()
 # clang specific
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     target_compile_options(ramses-build-options-base INTERFACE
-        -Winconsistent-missing-override -Wmove
+        -Wimplicit-fallthrough -Winconsistent-missing-override -Wmove
         -Winconsistent-missing-destructor-override)
 
     #  do not optimize debug build at all (-Og is wrong on clang)


### PR DESCRIPTION
-Wimplicit-fallthrough is being caught by the ramses build with this PR.